### PR TITLE
Fix find_in_workspaces to work with bundle prefix paths

### DIFF
--- a/ament_virtualenv/setup.py
+++ b/ament_virtualenv/setup.py
@@ -9,6 +9,8 @@ setup(
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/' + package_name, ['package.xml']),
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
     ],
     install_requires=['setuptools'],
     zip_safe=False,


### PR DESCRIPTION
The logic in here required that "/install/" be part of the prefix path. This is not the case for our bundle which just points to the root directory.