### PR TITLE
Rename "install" to "install_venv"

### DIFF
--- a/ament_virtualenv/setup.py
+++ b/ament_virtualenv/setup.py
@@ -35,7 +35,7 @@ setup(
             'build_venv = ament_virtualenv.build_venv:main',
             'combine_requirements = ament_virtualenv.combine_requirements:main',
             'glob_requirements = ament_virtualenv.glob_requirements:main',
-            'install = ament_virtualenv.install:main',
+            'install_venv = ament_virtualenv.install:main',
             'wrap_module = ament_virtualenv.wrap_module:main',
             'wrap_package = ament_virtualenv.wrap_package:main',
         ],


### PR DESCRIPTION
This script conflicts with the linux tool "install" which is used at least by preflight. Since this script isn't even used by anything as far as the build system goes rename it to "install_venv"