### PR TITLE
Make test_ament_virtualenv workable

### DIFF
--- a/test_ament_virtualenv/requirements.txt
+++ b/test_ament_virtualenv/requirements.txt
@@ -1,1 +1,1 @@
-requests
+gdown==5.2.0

--- a/test_ament_virtualenv/scripts/main.py
+++ b/test_ament_virtualenv/scripts/main.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+import sys
+
+from test_ament_virtualenv.test_ament_virtualenv import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test_ament_virtualenv/setup.cfg
+++ b/test_ament_virtualenv/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/test_ament_virtualenv
+[install]
+install_scripts=$base/lib/test_ament_virtualenv

--- a/test_ament_virtualenv/setup.py
+++ b/test_ament_virtualenv/setup.py
@@ -1,3 +1,5 @@
+import os
+
 from setuptools import setup
 import setuptools.command.install
 import ament_virtualenv.install
@@ -7,9 +9,11 @@ package_name = 'test_ament_virtualenv'
 class InstallCommand(setuptools.command.install.install):
     def run(self):
         super().run()
-        ament_virtualenv.install.install_venv(self.install_base, package_name)
-        # instead of self.install_base we may also use:
-        # self.config_vars['platbase'] or self.config_vars['base']
+        scripts_base = os.path.join(self.install_base, "lib/{}".format(package_name))
+        ament_virtualenv.install.install_venv(install_base = self.install_base,
+                                              package_name = package_name,
+                                              scripts_base = scripts_base,
+                                              )
         return
 
 setup(
@@ -20,7 +24,10 @@ setup(
     version='0.0.5',
     packages=[package_name],
     data_files=[
-        ('share/'+package_name, ['package.xml', 'requirements.txt']),
+        ('share/ament_index/resource_index/packages',
+         ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml', 'requirements.txt']),
+        ('lib/' + package_name, ['scripts/main.py'])
     ],
     install_requires=['setuptools'],
     zip_safe=False,
@@ -38,9 +45,4 @@ setup(
     description='Example of using ament_virtualenv.',
     license='Apache License, Version 2.0',
     tests_require=['pytest'],
-    entry_points={
-        'console_scripts': [
-            'test_ament_virtualenv = test_ament_virtualenv.test_ament_virtualenv:main',
-        ],
-    },
 )

--- a/test_ament_virtualenv/test_ament_virtualenv/test_ament_virtualenv.py
+++ b/test_ament_virtualenv/test_ament_virtualenv/test_ament_virtualenv.py
@@ -20,44 +20,25 @@
 
 import importlib
 import sys
+import gdown
 
-def main(args=None):
-    # 1: Test if we're in a virtual environment at all.
-    is_in_venv = hasattr(sys, 'real_prefix')
-    if not is_in_venv:
-        print(
-            "[test_ament_virtualenv] "
-            "FAILURE: Python virtual environment not activated."
-        )
-        return 1
-    # 2: Test the Python version.
-    if sys.version_info.major != 2:
-        print(
-            "[test_ament_virtualenv] "
-            "FAILURE: Wrong Python version."
-        )
-        return 1
-    # 3: Test if proper requirements have been installed
+def main(args=None):    
+    # Test if proper requirements have been installed
     try:
-        requests = importlib.import_module("requests")
-        if requests.__version__ != '2.20.1':
+        gdown = importlib.import_module("gdown")
+        if gdown.__version__ != '5.2.0':
             print(
                 "[test_ament_virtualenv] "
                 "FAILURE: Requirements not provided correctly "
-                "(expected 'requests==2.20.1', found "+requests.__version__+")"
+                "(expected 'gdown==5.2.0', found "+gdown.__version__+")"
             )
             return 1
     except:
         print(
             "[test_ament_virtualenv] "
             "FAILURE: Requirements not provided "
-            "(expected 'requests' to be present but could not find it)"
+            "(expected 'gdown' to be present but could not find it)"
         )
         return 1
     print("[test_ament_virtualenv] SUCCESS: All checks passed.")
     return 0
-
-
-if __name__ == '__main__':
-    sys.exit(main())
-


### PR DESCRIPTION
This PR fixes `test_ament_virtualenv` . 

Following the README.md, I couldn't use `ament_virtualenv` . I learned how to use `ament_virtualenv` after a few tries. I want to share the usage by applying the patch to `test_ament_virtualenv` . Is this PR's usage correct?
